### PR TITLE
Added a mock cloud provider client which wastes 1 second setting tags.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +805,7 @@ name = "k8s-cloud-tagger"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "futures",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3.31"
 axum = "0.8.8"
 http = "1.4.0"
 prometheus = "0.14.0"
+async-trait = "0.1.89"
 
 [dev-dependencies]
 tower-test = "0.4.0"

--- a/src/cloud/mock.rs
+++ b/src/cloud/mock.rs
@@ -1,0 +1,34 @@
+use super::{CloudClient, Labels};
+use crate::error::Error;
+use async_trait::async_trait;
+use std::time::Duration;
+
+pub struct MockClient {
+    delay: Duration,
+}
+
+impl MockClient {
+    pub fn new(delay: Duration) -> Self {
+        Self { delay }
+    }
+}
+
+impl Default for MockClient {
+    fn default() -> Self {
+        Self::new(Duration::from_secs(1))
+    }
+}
+
+#[async_trait]
+impl CloudClient for MockClient {
+    fn provider_name(&self) -> &'static str {
+        "mock"
+    }
+
+    async fn set_tags(&self, resource_id: &str, tags: &Labels) -> Result<(), Error> {
+        tracing::debug!(%resource_id, ?tags, "Mock: setting tags");
+        // Simulate API latency
+        tokio::time::sleep(self.delay).await;
+        Ok(())
+    }
+}

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -1,0 +1,39 @@
+mod mock;
+
+pub use mock::MockClient;
+
+use crate::error::Error;
+use crate::metrics::API_CALL_DURATION;
+use async_trait::async_trait;
+use std::collections::BTreeMap;
+
+pub type Labels = BTreeMap<String, String>;
+
+#[async_trait]
+pub trait CloudClient: Send + Sync {
+    fn provider_name(&self) -> &'static str;
+
+    async fn set_tags(&self, resource_id: &str, labels: &Labels) -> Result<(), Error>;
+}
+
+/// Wrapper which adds metrics to any CloudClient
+pub struct MeteredClient<C: CloudClient> {
+    inner: C,
+}
+
+impl<C: CloudClient> MeteredClient<C> {
+    pub fn new(inner: C) -> Self {
+        Self { inner }
+    }
+
+    pub async fn set_tags(&self, resource_id: &str, labels: &Labels) -> Result<(), Error> {
+        let start = std::time::Instant::now();
+        let result = self.inner.set_tags(resource_id, labels).await;
+
+        API_CALL_DURATION
+            .with_label_values(&[self.inner.provider_name(), "set_tags"])
+            .observe(start.elapsed().as_secs_f64());
+
+        result
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod cloud;
 mod config;
 mod error;
 mod health;
@@ -6,6 +7,7 @@ mod reconciler;
 mod resources;
 mod traits;
 
+use crate::cloud::{MeteredClient, MockClient};
 use crate::reconciler::Context;
 use crate::reconciler::{error_policy, reconcile};
 use futures::StreamExt;
@@ -40,6 +42,7 @@ async fn main() -> anyhow::Result<()> {
     let ctx = Arc::new(Context {
         client: client.clone(),
         config: cfg,
+        cloud: MeteredClient::new(MockClient::default()),
     });
 
     let pvc_ctrl = controller!(PersistentVolumeClaim, client, ctx);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -44,7 +44,7 @@ pub static ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
 });
 
 /// Duration of external API calls in seconds
-pub static _API_CALL_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
+pub static API_CALL_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         "api_call_duration_seconds",
         "Duration of external API calls",


### PR DESCRIPTION
`CloudClient.set_tags` wastes 1 second pretending to set tags. So we should get some metrics later in Grafana.